### PR TITLE
Update crm.uf.js

### DIFF
--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -510,8 +510,8 @@
         options: YESNO
       },
       'add_to_group_id': {
-        title: ts('Add new contacts to a Group?'),
-        help: ts('Select a group if you are using this profile for adding new contacts, AND you want the new contacts to be automatically assigned to a group.'),
+        title: ts('Add contacts to a group?'),
+        help: ts('Select a group if you want contacts to be automatically added to that group when the profile is submitted.'),
         type: 'Number'
       },
       'cancel_URL': {


### PR DESCRIPTION
Overview
----------------------------------------
Edited help text and description for add to group in profile settings, per https://lab.civicrm.org/dev/core/-/issues/1950

Before
----------------------------------------
Option labelled  "Add new contacts to a Group?" with a help text "Select a group if you are using this profile for adding new contacts, AND you want the new contacts to be automatically assigned to a group."

After
----------------------------------------
Option labelled  "Add contacts to a group?" with a help text "
Select a group if you want contacts to be automatically added to that group when the profile is submitted."

