### PR TITLE
Api4 - Update label for is_deceased & deceased_date per contact type

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/ContactSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContactSpecProvider.php
@@ -21,12 +21,37 @@ use Civi\Api4\Utils\CoreUtil;
  * @service
  * @internal
  */
-class ContactGetSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+class ContactSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
 
   /**
    * @param \Civi\Api4\Service\Spec\RequestSpec $spec
    */
   public function modifySpec(RequestSpec $spec) {
+
+    if ($spec->getValue('contact_type') === 'Individual') {
+      $spec->getFieldByName('is_deceased')
+        ->setTitle(ts('Is Deceased'))
+        ->setLabel(ts('Deceased'));
+      $spec->getFieldByName('deceased_date')
+        ->setTitle(ts('Deceased Date'))
+        ->setLabel(ts('Deceased Date'))
+        ->setDescription(ts('Date deceased'));
+    }
+    if ($spec->getValue('contact_type') === 'Household' || $spec->getValue('contact_type') === 'Organization') {
+      $spec->getFieldByName('is_deceased')
+        ->setTitle(ts('Is Closed'))
+        ->setLabel(ts('Closed'));
+      $spec->getFieldByName('deceased_date')
+        ->setTitle(ts('Closed Date'))
+        ->setLabel(ts('Closed Date'))
+        ->setDescription(ts('Date closed or disbanded'));
+    }
+
+    // All other fields in this file are specific to the `get` action.
+    if ($spec->getAction() !== 'get') {
+      return;
+    }
+
     // Groups field
     $field = new FieldSpec('groups', $spec->getEntity(), 'Array');
     $field->setLabel(ts('In Groups'))
@@ -137,7 +162,7 @@ class ContactGetSpecProvider extends \Civi\Core\Service\AutoService implements G
    */
   public function applies($entity, $action) {
     // Applies to 'Contact' plus pseudo-entities 'Individual', 'Organization', 'Household'
-    return CoreUtil::isContact($entity) && $action === 'get';
+    return CoreUtil::isContact($entity);
   }
 
   /**

--- a/deleted-files-list.json
+++ b/deleted-files-list.json
@@ -595,6 +595,7 @@
     "Civi/Api4/Service/Spec/Provider/CaseCreationSpecProvider.php",
     "Civi/Api4/Service/Spec/Provider/CaseTypeGetSpecProvider.php",
     "Civi/Api4/Service/Spec/Provider/ContactCreationSpecProvider.php",
+    "Civi/Api4/Service/Spec/Provider/ContactGetSpecProvider.php",
     "Civi/Api4/Service/Spec/Provider/ContributionCreationSpecProvider.php",
     "Civi/Api4/Service/Spec/Provider/ContributionGetSpecProvider.php",
     "Civi/Api4/Service/Spec/Provider/ContributionRecurCreationSpecProvider.php",


### PR DESCRIPTION
Updates labels depending on the contact type specified, for SearchKit, etc.
